### PR TITLE
DialogBusy replaced with DialogBusyNoCancel

### DIFF
--- a/default.py
+++ b/default.py
@@ -203,9 +203,9 @@ class VideoExtras(VideoExtrasBase):
 
     def findExtras(self, exitOnFirst=False, extrasDb=None, defaultFanArt=""):
         # Display the busy icon while searching for files
-        xbmc.executebuiltin("ActivateWindow(busydialog)")
+        xbmc.executebuiltin("ActivateWindow(busydialognocancel)")
         files = VideoExtrasBase.findExtras(self, exitOnFirst, extrasDb, defaultFanArt)
-        xbmc.executebuiltin("Dialog.Close(busydialog)")
+        xbmc.executebuiltin("Dialog.Close(busydialognocancel)")
         return files
 
     # Enable and disable the display of the extras button


### PR DESCRIPTION
https://forum.kodi.tv/showthread.php?tid=303073&pid=2739256#pid2739256

Usage of DialogBusy results in nop now. I removed it becuase it was wrong: 13954 (PR)

Unfortunately Kodi's GUI lacks a proper MVC (model view controller) architecture. Giving addons the chance to open modal dialogs in an uncontrolled manner is wrong. In this particular case it lead to crashes that I fixed with this change. DialogBusy is a singelto and must only be used once at a given time.

EDIT: as a workaround python scripts can make use of the new DialogBusyNoCancel: 13958 (PR)